### PR TITLE
Fix the confessional_test host-recap flake that had main's CI red

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -681,6 +681,25 @@ smoke-test, and `build/` + `steam_appid.txt` gitignored.
   AI content" disclosure box honestly — with the heuristic-only build this
   is canned-lines-only and simpler to answer.
 
+## The host-recap flake, fourth sighting of the cooldown-swallow (2026-09-02)
+
+CI's `tests` workflow went red on main — including on the docs-only
+roadmap commit, so it predated all feature work. confessional_test was
+the ONE harness missing the standard neutralization block: its manual
+`day_changed(3)` (test 8) let EventManager roll organic events and
+ArcManager start spontaneous arcs, and EventManager's handler connects
+first (autoload order), so a fired event's 6.0 narrative recorded a
+"drama" quip whose 8s cooldown silently swallowed the host recap under
+test. `fired=true kind_ok=false` — the cooldown-swallow class, again.
+
+Reproduced deterministically: a sandbox copy with event probabilities
+x10 fails the old file with the exact CI signature and passes the fixed
+one 3/3 under the same odds. Fix: zero probabilities +
+`ArcManager.auto_start_enabled = false` + the autosave guard in
+confessional_test. **Deliberate exception: this harness must NOT set
+`TimeManager.is_paused = true`** — ConfessionalDirector._process only
+decays the cooldown while the clock runs, and `_cool()` depends on it.
+
 ## The Premiere package (2026-08-31, Roadmap Now #1)
 
 The first hour now proves the game instead of hoping. Two pieces:

--- a/scenes/main/confessional_test.gd
+++ b/scenes/main/confessional_test.gd
@@ -23,6 +23,18 @@ func _ready() -> void:
 	SynergyManager.auto_enabled = false
 	SecretManager.auto_assign_enabled = false
 	SecretManager.auto_admit_enabled = false
+	# The rest of the standard neutralization block. This harness was the one
+	# holdout without it, and test 8's manual day_changed(3) paid for that at
+	# ~flake rate on CI: an organic event roll (or a spontaneous arc) landed a
+	# 6.0 narrative event first, the director recorded a "drama" quip, and its
+	# 8s cooldown silently swallowed the host recap under test — the
+	# cooldown-swallow class, again. One deliberate exception: TimeManager is
+	# NOT paused here, because the director's cooldown only decays while the
+	# clock runs and _cool() depends on that.
+	for definition in EventManager.get_available_events():
+		definition.probability = 0.0
+	ArcManager.auto_start_enabled = false
+	SaveManager._last_auto_save_day = 999999
 	EventBus.confessional_recorded.connect(_on_confessional)
 	_build_world()
 	_spawn(4)


### PR DESCRIPTION
The `tests` workflow has been intermittently red on `main` — including on the docs-only roadmap commit (`9fd4e60`), so it predates the Now-horizon merge. The failure was always the same pair:

```
FAIL  day change produces host recap (fired=true kind_ok=false speaker_ok=false)
FAIL  host recap not flagged correctly
```

**Root cause:** `confessional_test` was the one harness missing the repo's standard neutralization block. Its manual `day_changed(3)` (test 8) let `EventManager` roll organic events — and EventManager's handler connects before ConfessionalDirector's (autoload order), so a fired event's importance-6.0 narrative recorded a "drama" quip whose 8-second cooldown silently swallowed the host recap under test. The cooldown-swallow class from PLAN.md's gotchas, fourth sighting. Spontaneous `ArcManager` starts were a second competing source.

**Proof:** reproduced deterministically in a sandbox copy with event probabilities ×10 — the old file fails with the exact CI signature; the fixed file passes 3/3 under the same inflated odds, and the full suite (378 assertions, 9 harnesses) is green.

**Fix:** zero event probabilities, `ArcManager.auto_start_enabled = false`, and the autosave guard in `confessional_test._ready`, with a comment documenting the one deliberate exception — `TimeManager` stays unpaused because the director's cooldown only decays while the clock runs and `_cool()` depends on it. PLAN.md records the sighting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLsBPELXp28Kuv7eDnuEhF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLsBPELXp28Kuv7eDnuEhF)_